### PR TITLE
Fix issue when copying nodes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 sphinx-asdf
 ===========
 
-.. image:: https://github.com/asdf-format/sphinx_asdf/workflows/CI/badge.svg
-    :target: https://github.com/asdf-format/sphinx_asdf/actions
+.. image:: https://github.com/asdf-format/sphinx-asdf/workflows/CI/badge.svg
+    :target: https://github.com/asdf-format/sphinx-asdf/actions
     :alt: CI Status
 
 ``sphinx-asdf`` is a plugin for `sphinx`_ that enables generation of

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ setup_requires = setuptools_scm
 install_requires =
     pyyaml
     mistune
+    sphinx
     sphinx_bootstrap_theme
 
 [options.extras_require]

--- a/sphinx_asdf/directives.py
+++ b/sphinx_asdf/directives.py
@@ -398,7 +398,7 @@ class AsdfSchema(SphinxDirective):
 
         prop = schema_property(id=path)
         prop.append(schema_property_name(text=name))
-        prop.append(schema_property_details(typ, required, ref))
+        prop.append(schema_property_details(typ=typ, required=required, ref=ref))
         prop.append(self._parse_description(description, ''))
         if typ != 'object':
             prop.extend(self._process_validation_keywords(tree, typename=typ, path=path))

--- a/sphinx_asdf/nodes.py
+++ b/sphinx_asdf/nodes.py
@@ -67,12 +67,8 @@ class section_header(nodes.line):
 
 class schema_properties(nodes.compound):
 
-    def __init__(self, *args, **kwargs):
-        self.id = kwargs.pop('id', '')
-        super().__init__(*args, **kwargs)
-
     def visit_html(self, node):
-        self.body.append(r'<div class="schema_properties" id="{}">'.format(node.id))
+        self.body.append(r'<div class="schema_properties" id="{}">'.format(node.get('id')))
 
     def depart_html(self, node):
         self.body.append(r'</div>')
@@ -80,12 +76,8 @@ class schema_properties(nodes.compound):
 
 class schema_property(nodes.compound):
 
-    def __init__(self, *args, **kwargs):
-        self.id = kwargs.pop('id', '')
-        super().__init__(*args, **kwargs)
-
     def visit_html(self, node):
-        self.body.append(r'<li class="list-group-item" id="{}">'.format(node.id))
+        self.body.append(r'<li class="list-group-item" id="{}">'.format(node.get('id')))
 
     def depart_html(self, node):
         self.body.append(r'</li>')
@@ -102,21 +94,15 @@ class schema_property_name(nodes.line):
 
 class schema_property_details(nodes.compound):
 
-    def __init__(self, typ, required, ref=None, *args, **kwargs):
-        self.typ = typ
-        self.ref = ref
-        self.required = required
-        super().__init__(*args, **kwargs)
-
     def visit_html(self, node):
         self.body.append(r'<table><tr>')
         self.body.append('<td><b>')
-        if node.ref is not None:
-            self.body.append('<a href={}>{}</a>'.format(node.ref, node.typ))
+        if node.get('ref', None) is not None:
+            self.body.append('<a href={}>{}</a>'.format(node.get('ref'), node.get('typ')))
         else:
-            self.body.append(node.typ)
+            self.body.append(node.get('typ'))
         self.body.append('</b></td>')
-        if node.required:
+        if node.get('required'):
             self.body.append(r'<td><em>Required</em></td>')
 
     def depart_html(self, node):
@@ -134,13 +120,8 @@ class asdf_tree(nodes.bullet_list):
 
 class asdf_ref(nodes.line):
 
-    def __init__(self, *args, **kwargs):
-        self.text = kwargs['text']
-        self.href = kwargs.pop('href')
-        super().__init__(*args, **kwargs)
-
     def visit_html(self, node):
-        self.body.append('<a class="asdf_ref" href="{}">'.format(node.href))
+        self.body.append('<a class="asdf_ref" href="{}">'.format(node.get('href')))
 
     def depart_html(self, node):
         self.body.append(r'</a>')
@@ -174,17 +155,13 @@ class example_description(nodes.compound):
 
 class schema_combiner_body(nodes.compound):
 
-    def __init__(self, *args, path='', **kwargs):
-        self.path = path
-        super().__init__(*args, **kwargs)
-
     def visit_html(self, node):
         self.body.append("""
 <button class="btn btn-primary" data-toggle="collapse" href="#{0}" aria-expanded="false">
     <span class="hidden">Hide </span>Details
 </button>
 <div class="collapse" id="{0}">
-        """.format(node.path))
+        """.format(node.get('path')))
 
     def depart_html(self, node):
         self.body.append('</div>')

--- a/tests/test_sphinx_asdf.py
+++ b/tests/test_sphinx_asdf.py
@@ -34,21 +34,21 @@ def test_basic_generation(app, status, warning):
     assert ('.. asdf-schema::\n'
             '    :schema_root: schemas\n'
             '\n'
-            '    foo\n') in foo_doc.text()
+            '    foo\n') in foo_doc.read_text()
 
     bar_doc = (app.srcdir / 'generated' / 'bar.rst')
     assert bar_doc.exists()
     assert ('.. asdf-schema::\n'
             '    :schema_root: schemas\n'
             '\n'
-            '    bar\n') in bar_doc.text()
+            '    bar\n') in bar_doc.read_text()
 
     baz_doc = (app.srcdir / 'generated' / 'core' / 'baz.rst')
     assert baz_doc.exists()
     assert ('.. asdf-schema::\n'
             '    :schema_root: schemas\n'
             '\n'
-            '    core/baz\n') in baz_doc.text()
+            '    core/baz\n') in baz_doc.read_text()
 
 
 @pytest.mark.sphinx('dummy', testroot='global-config')
@@ -60,21 +60,21 @@ def test_generation_global_config(app, status, warning):
     assert ('.. asdf-schema::\n'
             '    :schema_root: a/b/c/schemas\n'
             '\n'
-            '    foo\n') in foo_doc.text()
+            '    foo\n') in foo_doc.read_text()
 
     bar_doc = (app.srcdir / 'generated' / 'bar.rst')
     assert bar_doc.exists()
     assert ('.. asdf-schema::\n'
             '    :schema_root: a/b/c/schemas\n'
             '\n'
-            '    bar\n') in bar_doc.text()
+            '    bar\n') in bar_doc.read_text()
 
     baz_doc = (app.srcdir / 'generated' / 'core' / 'baz.rst')
     assert baz_doc.exists()
     assert ('.. asdf-schema::\n'
             '    :schema_root: a/b/c/schemas\n'
             '\n'
-            '    core/baz\n') in baz_doc.text()
+            '    core/baz\n') in baz_doc.read_text()
 
 
 @pytest.mark.sphinx('dummy', testroot='global-prefix')
@@ -87,7 +87,7 @@ def test_generation_global_prefix(app, status, warning):
             '    :standard_prefix: a/b/c\n'
             '    :schema_root: schemas\n'
             '\n'
-            '    foo\n') in foo_doc.text()
+            '    foo\n') in foo_doc.read_text()
 
     bar_doc = (app.srcdir / 'generated' / 'a' / 'b' / 'c' / 'bar.rst')
     assert bar_doc.exists()
@@ -95,7 +95,7 @@ def test_generation_global_prefix(app, status, warning):
             '    :standard_prefix: a/b/c\n'
             '    :schema_root: schemas\n'
             '\n'
-            '    bar\n') in bar_doc.text()
+            '    bar\n') in bar_doc.read_text()
 
     baz_doc = (app.srcdir / 'generated' / 'a' / 'b' / 'c' / 'core' / 'baz.rst')
     assert baz_doc.exists()
@@ -103,7 +103,7 @@ def test_generation_global_prefix(app, status, warning):
             '    :standard_prefix: a/b/c\n'
             '    :schema_root: schemas\n'
             '\n'
-            '    core/baz\n') in baz_doc.text()
+            '    core/baz\n') in baz_doc.read_text()
 
 
 @pytest.mark.sphinx('dummy', testroot='basic-generation')
@@ -113,10 +113,10 @@ def test_basic_build(app, status, warning):
     # Test each of the generated schema documents
     for name in ['foo', 'bar', 'core/baz']:
         doctree_path = app.doctreedir / 'generated' / '{}.doctree'.format(name)
-        doc = pickle.loads(doctree_path.bytes())
+        doc = pickle.loads(doctree_path.read_bytes())
 
-        title = doc.traverse(nodes.title)[0]
+        title = list(doc.traverse(nodes.title))[0]
         assert title.astext() == name
 
-        schema_top = doc.traverse(sa_nodes.schema_doc)
+        schema_top = list(doc.traverse(sa_nodes.schema_doc))
         assert len(schema_top) > 0


### PR DESCRIPTION
The node classes in this repo were defining custom attributes in a quirky way which causes failures when the nodes are copied.  This updates them to access custom attributes in the standard way and also fixes some deprecation warnings and adds sphinx as a package dependency.