### PR TITLE
rename references from master to main

### DIFF
--- a/.github/workflows/sphinx_asdf_ci.yml
+++ b/.github/workflows/sphinx_asdf_ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,10 @@ you would like to see. If there is an issue you would like to work on, please
 leave a comment and we will be happy to assist. New contributions and
 contributors are very welcome!
 
-The main development work is done on the "master" branch. The "stable" branch is
+The main development work is done on the "main" branch. The "stable" branch is
 protected and used for official releases. The rest of the branches are for
 release maintenance and should not be used normally. Unless otherwise told by a
-maintainer, pull request should be made and submitted to the "master" branch.
+maintainer, pull request should be made and submitted to the "main" branch.
 
 New to github or open source projects? If you are unsure about where to start or
 haven't used github before, please feel free to contact the package maintainers.

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To install the latest release on PyPI::
 
     $ pip install sphinx-asdf
 
-The latest development version is available from the ``master`` branch `on
+The latest development version is available from the ``main`` branch `on
 github`_. To clone the project:
 
 ::


### PR DESCRIPTION
After this PR is merged the `master` branch should be renamed to `main`.