### PR TITLE
fix testing against downstream packages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals=
     git
 commands=
     git clone https://github.com/asdf-format/asdf-standard
-    pip install asdf-standard[docs]
+    pip install ./asdf-standard[docs]
     sphinx-build asdf-standard/docs/source asdf-standard/docs/build
 
 [testenv:asdf]
@@ -24,7 +24,7 @@ allowlist_externals=
     git
 commands=
     git clone https://github.com/asdf-format/asdf
-    pip install asdf[docs]
+    pip install ./asdf[docs]
     sphinx-build asdf/docs asdf/docs/build
 
 [testenv:asdf-transform-schemas]
@@ -35,7 +35,7 @@ allowlist_externals=
     git
 commands=
     git clone https://github.com/asdf-format/asdf-transform-schemas
-    pip install asdf-transform-schemas[docs]
+    pip install ./asdf-transform-schemas[docs]
     sphinx-build asdf-transform-schemas/docs asdf-transform-schemas/docs/build
 
 [testenv:asdf-coordinates-schemas]
@@ -46,7 +46,7 @@ allowlist_externals=
     git
 commands=
     git clone https://github.com/asdf-format/asdf-coordinates-schemas
-    pip install asdf-coordinates-schemas[docs]
+    pip install ./asdf-coordinates-schemas[docs]
     sphinx-build asdf-coordinates-schemas/docs asdf-coordinates-schemas/docs/build
 
 [testenv:asdf-wcs-schemas]
@@ -57,7 +57,7 @@ allowlist_externals=
     git
 commands=
     git clone https://github.com/asdf-format/asdf-wcs-schemas
-    pip install asdf-wcs-schemas[docs]
+    pip install ./asdf-wcs-schemas[docs]
     sphinx-build asdf-wcs-schemas/docs asdf-wcs-schemas/docs/build
 
 [testenv:asdf-astropy]
@@ -68,7 +68,7 @@ allowlist_externals=
     git
 commands=
     git clone https://github.com/astropy/asdf-astropy
-    pip install asdf-astropy[docs]
+    pip install ./asdf-astropy[docs]
     sphinx-build asdf-astropy/docs asdf-astropy/docs/build
 
 [testenv:twine]


### PR DESCRIPTION
The CI builds docs for development packages using the released version. See the issue below for more details.

Fixes https://github.com/asdf-format/sphinx-asdf/issues/61