### PR TITLE
fix deprecated usage

### DIFF
--- a/sphinx_asdf/asdf2rst.py
+++ b/sphinx_asdf/asdf2rst.py
@@ -91,7 +91,7 @@ class AsdfDirective(Directive):
 
             if show_bocks:
                 with asdf.open(filename, **kwargs) as ff:
-                    for i, block in enumerate(ff.blocks.internal_blocks):
+                    for i, block in enumerate(ff._blocks.internal_blocks):
                         data = codecs.encode(block.data.tobytes(), "hex")
                         if len(data) > 40:
                             data = data[:40] + b"..."
@@ -127,10 +127,10 @@ class AsdfDirective(Directive):
                         set_source_info(self, literal)
                         parts.append(literal)
 
-                    internal_blocks = list(ff.blocks.internal_blocks)
+                    internal_blocks = list(ff._blocks.internal_blocks)
                     if len(internal_blocks) and internal_blocks[-1].array_storage != "streamed":
                         buff = io.BytesIO()
-                        ff.blocks.write_block_index(buff, ff)
+                        ff._blocks.write_block_index(buff, ff)
                         block_index = buff.getvalue().decode("utf-8")
                         literal = nodes.literal_block(block_index, block_index)
                         literal["language"] = "yaml"

--- a/tests/test_sphinx_asdf.py
+++ b/tests/test_sphinx_asdf.py
@@ -92,8 +92,8 @@ def test_basic_build(app, status, warning):
         doctree_path = app.doctreedir / "generated" / f"{name}.doctree"
         doc = pickle.loads(doctree_path.read_bytes())
 
-        title = list(doc.traverse(nodes.title))[0]
+        title = list(doc.findall(nodes.title))[0]
         assert title.astext() == name
 
-        schema_top = list(doc.traverse(sa_nodes.schema_doc))
+        schema_top = list(doc.findall(sa_nodes.schema_doc))
         assert len(schema_top) > 0


### PR DESCRIPTION
This PR updates deprecated uses of:
- `AsdfFile.blocks`
- `sphinx.io.read_doc`
- `Nodes.traverse`

fixes #58 
fixes #52 