### PR TITLE
remove mistune approximate pin, add 3.0 compatibility, add 3.0 lower pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     graphviz
     matplotlib
     myst-parser
-    mistune~=0.8.4
+    mistune
     sphinx
     sphinx-astropy
     sphinx_bootstrap_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     graphviz
     matplotlib
     myst-parser
-    mistune
+    mistune>=3
     sphinx
     sphinx-astropy
     sphinx_bootstrap_theme

--- a/sphinx_asdf/md2rst.py
+++ b/sphinx_asdf/md2rst.py
@@ -1,192 +1,46 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
-Implements a markdown to reST converter using the mistune markdown
-parser.
-
-This module was written by Michael Droetboom and has been copied from
-http://github.com/spacetelescope/asdf-standard. See
-../licenses/ASDF_STANDARD_LICENSE.rst for license information.
+We aren't using the built in mistune math plugin here
+to maintain consistency with the old custom markdown to
+rst converter that used to be in this file.
 """
 
 import re
 import textwrap
 
 import mistune
+from mistune.renderers.rst import RSTRenderer
 
 
-class BlockLexer(mistune.BlockLexer):
-    # Adds math support
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.enable_math()
-
-    def enable_math(self):
-        self.rules.block_math = re.compile(r"^\$\$(.*?)\$\$", re.DOTALL)
-        self.default_rules = ["block_math"] + mistune.BlockLexer.default_rules
-
-    def parse_block_math(self, m):
-        self.tokens.append({"type": "block_math", "text": m.group(1)})
+def inline_math_to_rst(renderer, content, block_state):
+    return f":math:`{content['raw']}`"
 
 
-class Markdown(mistune.Markdown):
-    def output_block_math(self):
-        return self.renderer.block_math(self.token["text"])
+def block_math_to_rst(renderer, content, block_state):
+    out = ".. math::\n\n"
+    out += "\n".join("   " + line for line in textwrap.dedent(content["raw"]).split("\n"))
+    out += "\n\n"
+    return out
 
 
-class InlineLexer(mistune.InlineLexer):
-    # Adds math support
-
-    default_rules = ["math"] + mistune.InlineLexer.default_rules
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.enable_math()
-
-    def enable_math(self):
-        self.rules.text = re.compile(r"^[\s\S]+?(?=[\\<!\[_*`~$]|https?://| {2,}\n|$)")
-        self.rules.math = re.compile(r"^\$(.+?)\$")
-        self.default_rules = ["math"] + mistune.InlineLexer.default_rules
-
-    def output_math(self, m):
-        return self.renderer.math(m.group(1))
+def parse_inline_math(inline, m, state):
+    text = m.group("math_text")
+    state.append_token({"type": "inline_math", "raw": text})
+    return m.end()
 
 
-class RstRenderer:
-    """The default HTML renderer for rendering Markdown."""
-
-    def __init__(self, **kwargs):
-        self.options = kwargs
-        self.levels = kwargs.get("levels", '*=-^"+:~')
-
-    def _indented(self, content):
-        content = textwrap.dedent(content)
-        return "\n".join("   " + line for line in content.split("\n"))
-
-    def _directive(self, name, content, args=[], attributes={}):
-        out = ".. {}:: {}\n".format(name, ", ".join(args))
-        for key, val in attributes.items():
-            out += f"    :{key}: {val}\n"
-        out += "\n"
-        out += self._indented(content)
-        out += "\n\n"
-        return out
-
-    def placeholder(self):
-        return ""
-
-    def block_code(self, code, lang=None):
-        code = code.rstrip("\n")
-        if lang:
-            langs = [lang]
-        else:
-            langs = ["none"]
-        return self._directive("code-block", code, langs)
-
-    def block_quote(self, text):
-        return self._indented(text)
-
-    def block_html(self, html):
-        if self.options.get("skip_html"):
-            return ""
-        return self._directive("raw", html, ["html"])
-
-    def header(self, text, level, raw=None):
-        return f"{text}\n{self.levels[level] * len(text)}\n\n"
-
-    def hrule(self):
-        return "\n\n--------\n\n"
-
-    def list(self, body, ordered=True):
-        if ordered:
-            body = ("\n" + body).replace("\n- ", "\n#.")
-        return body
-
-    def list_item(self, text):
-        return textwrap.fill(text, initial_indent="-  ", subsequent_indent="   ") + "\n\n"
-
-    def paragraph(self, text):
-        return "%s\n\n" % text
-
-    def table(self, header, body):
-        raise NotImplementedError()
-
-    def table_row(self, content):
-        raise NotImplementedError()
-
-    def table_cell(self, content, **flags):
-        raise NotImplementedError()
-
-    def double_emphasis(self, text):
-        return "**%s**" % text
-
-    def emphasis(self, text):
-        return "*%s*" % text
-
-    def codespan(self, text):
-        return ":code:`%s`" % text
-
-    def linebreak(self):
-        return ""
-
-    def strikethrough(self, text):
-        return text
-
-    def text(self, text):
-        return text
-
-    def autolink(self, link, is_email=False):
-        text = link
-        if is_email:
-            link = "mailto:%s" % link
-        if link.startswith("ref:"):
-            return f":ref:`{text} <{link[4:]}>`"
-        return f"`{text} <{link}>`__"
-
-    def link(self, link, title, text):
-        if link.startswith("javascript:"):
-            link = ""
-        if link.startswith("ref:"):
-            return f":ref:`{text} <{link[4:]}>`"
-        return f"`{text} <{link}>`__"
-
-    def image(self, src, title, text):
-        if src.startswith("javascript:"):
-            src = ""
-        options = {}
-        if text:
-            options["alt"] = text
-        return self._directive("image", "", [src], options)
-
-    def tag(self, html):
-        if self.options.get("skip_html"):
-            return ""
-        return ":raw:`%s`" % html
-
-    def newline(self):
-        return ""
-
-    def footnote_ref(self, key, index):
-        raise NotImplementedError()
-
-    def footnote_item(self, key, text):
-        raise NotImplementedError()
-
-    def footnotes(self, text):
-        raise NotImplementedError()
-
-    def math(self, text):
-        return ":math:`%s`" % text
-
-    def block_math(self, text):
-        return self._directive("math", text)
+def parse_block_math(block, m, state):
+    text = m.group("math_text")
+    state.append_token({"type": "block_math", "raw": text})
+    return m.end() + 1
 
 
 def md2rst(content):
-    """
-    Convert the given string in markdown to a string of reST.
-    """
-    renderer = RstRenderer()
-    md = Markdown(block=BlockLexer, inline=InlineLexer, renderer=renderer)
-    return md.render(content)
+    renderer = RSTRenderer()
+    renderer.register("inline_math", inline_math_to_rst)
+    renderer.register("block_math", block_math_to_rst)
+    converter = mistune.create_markdown(renderer=renderer)
+    INLINE_MATH_PATTERN = r"\$\$?(?!\s)(?P<math_text>.+?)(?!\s)(?<!\\)\$\$?"
+    converter.inline.register("inline_math", INLINE_MATH_PATTERN, parse_inline_math, before="link")
+    BLOCK_MATH_PATTERN = r"(?s)\$\$(?P<math_text>.*?)\$\$"
+    converter.block.register("block_math", BLOCK_MATH_PATTERN, parse_block_math, before="list")
+    return converter(content)


### PR DESCRIPTION
The tests and the CI don't do a great job of testing these changes.

The use of mistune in sphinx-asdf is to convert markdown embedded in the ASDF schemas to rst for rendering in sphinx. This was previously handled with a custom rst renderer registered with mistune (which handled the markdown parsing). The mistune API changed significantly from 0.8 to 3.0. 3.0 includes a built in rst renderer (which this PR uses to replace the custom rst renderer). Mistune 3.0 also has a built-in math plugin. However, this is not compatible with the syntax used within the ASDF schemas. This PR uses the new mistune api and registers a custom plugin with regexes that are more similar to those used prior to this PR (using the exact regexes did not work and these needed changes to include inline flags, change group names, etc). (See related mistune math plugin issue: https://github.com/lepture/mistune/issues/330).

This screenshot shows the [conic schema in asdf-transform-schemas](https://asdf-transform-schemas.readthedocs.io/en/latest/generated/schemas/conic-1.3.0.html) rendered with this PR. Showing both inline and block math rendering:
<img width="824" alt="Screen Shot 2023-06-26 at 2 19 55 PM" src="https://github.com/asdf-format/sphinx-asdf/assets/114267/9ac4703a-bb85-4cf3-91ec-a1df9877328f">

Note that nbconvert (which also uses mistune and is the common cause of version conflicts with sphinx-asdf) only recently allowed mistune 3.0 so some users might need to update nbconvert.
https://github.com/jupyter/nbconvert/pull/1820

Fixes: https://jira.stsci.edu/browse/AL-707
