### PR TITLE
update required python to 3.9, drop unused deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,22 +12,18 @@ github_project = spacetelescope/sphinx-asdf
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.9
 include_package_data = True
 setup_requires = setuptools_scm
 install_requires =
     asdf
     astropy>=5.0.4
     docutils
-    graphviz
-    matplotlib
-    myst-parser
     mistune>=3
     sphinx
     sphinx-astropy
     sphinx_bootstrap_theme
     sphinx-rtd-theme
-    sphinx-inline-tabs
     toml
 
 [options.extras_require]

--- a/sphinx_asdf/conf.py
+++ b/sphinx_asdf/conf.py
@@ -38,4 +38,4 @@ html_favicon = f"{static_dir}/logo.ico"
 latex_logo = f"{static_dir}/logo.pdf"
 
 sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname("__file__")), "sphinxext"))
-extensions += ["sphinx_asdf", "sphinx_inline_tabs", "myst_parser"]
+extensions += ["sphinx_asdf"]


### PR DESCRIPTION
This required downstream changes as asdf depended on `sphinx-asdf` to include things like `graphviz` and `sphinx-inline-tabs` etc. https://github.com/asdf-format/asdf/pull/1567 added those deps to asdf (and docs building was tested against the source branch of this PR).