### PR TITLE
add more downstream packages to ci

### DIFF
--- a/.github/workflows/sphinx_asdf_ci.yml
+++ b/.github/workflows/sphinx_asdf_ci.yml
@@ -87,22 +87,22 @@ jobs:
             toxenv: rad
 
           - name: roman_datamodels Document Build
-            python-version: "3.9"
+            python-version: "3.11"
             os: ubuntu-latest
             toxenv: roman_datamodels
 
           - name: romancal Document Build
-            python-version: "3.9"
+            python-version: "3.11"
             os: ubuntu-latest
             toxenv: romancal
 
           - name: stdatamodels Document Build
-            python-version: "3.9"
+            python-version: "3.10"
             os: ubuntu-latest
             toxenv: stdatamodels
 
           - name: jwst Document Build
-            python-version: "3.9"
+            python-version: "3.11"
             os: ubuntu-latest
             toxenv: jwst
 

--- a/.github/workflows/sphinx_asdf_ci.yml
+++ b/.github/workflows/sphinx_asdf_ci.yml
@@ -81,6 +81,31 @@ jobs:
             os: ubuntu-latest
             toxenv: asdf-astropy
 
+          - name: rad Document Build
+            python-version: "3.9"
+            os: ubuntu-latest
+            toxenv: rad
+
+          - name: roman_datamodels Document Build
+            python-version: "3.9"
+            os: ubuntu-latest
+            toxenv: roman_datamodels
+
+          - name: romancal Document Build
+            python-version: "3.9"
+            os: ubuntu-latest
+            toxenv: romancal
+
+          - name: stdatamodels Document Build
+            python-version: "3.9"
+            os: ubuntu-latest
+            toxenv: stdatamodels
+
+          - name: jwst Document Build
+            python-version: "3.9"
+            os: ubuntu-latest
+            toxenv: jwst
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -113,7 +113,7 @@ allowlist_externals=
 commands=
     git clone https://github.com/spacetelescope/stdatamodels
     pip install ./stdatamodels[docs]
-    sphinx-build stdatamodels/docs stdatamodels/docs/build
+    sphinx-build stdatamodels/docs/source stdatamodels/docs/build
 
 [testenv:jwst]
 changedir={envtmpdir}

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,61 @@ commands=
     pip install ./asdf-astropy[docs]
     sphinx-build asdf-astropy/docs asdf-astropy/docs/build
 
+[testenv:rad]
+changedir={envtmpdir}
+deps=
+    sphinx
+allowlist_externals=
+    git
+commands=
+    git clone https://github.com/spacetelescope/rad
+    pip install ./rad[docs]
+    sphinx-build rad/docs rad/docs/build
+
+[testenv:roman_datamodels]
+changedir={envtmpdir}
+deps=
+    sphinx
+allowlist_externals=
+    git
+commands=
+    git clone https://github.com/spacetelescope/roman_datamodels
+    pip install ./roman_datamodels[docs]
+    sphinx-build roman_datamodels/docs roman_datamodels/docs/build
+
+[testenv:romancal]
+changedir={envtmpdir}
+deps=
+    sphinx
+allowlist_externals=
+    git
+commands=
+    git clone https://github.com/spacetelescope/romancal
+    pip install ./romancal[docs]
+    sphinx-build romancal/docs romancal/docs/build
+
+[testenv:stdatamodels]
+changedir={envtmpdir}
+deps=
+    sphinx
+allowlist_externals=
+    git
+commands=
+    git clone https://github.com/spacetelescope/stdatamodels
+    pip install ./stdatamodels[docs]
+    sphinx-build stdatamodels/docs stdatamodels/docs/build
+
+[testenv:jwst]
+changedir={envtmpdir}
+deps=
+    sphinx
+allowlist_externals=
+    git
+commands=
+    git clone https://github.com/spacetelescope/jwst
+    pip install ./jwst[docs]
+    sphinx-build jwst/docs jwst/docs/build
+
 [testenv:twine]
 deps=
     twine


### PR DESCRIPTION
The 0.2.0 release broke romancal docs.
https://github.com/spacetelescope/romancal/pull/773

This PR adds romancal (rad, roman_datamodels, jwst and stdatamodels) docs builds to the CI.