### PR TITLE
for docutils < 0.19 use traverse instead of findall

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     astropy>=5.0.4
     docutils
     mistune>=3
+    packaging
     sphinx
     sphinx-astropy
     sphinx_bootstrap_theme

--- a/sphinx_asdf/connections.py
+++ b/sphinx_asdf/connections.py
@@ -4,9 +4,9 @@ import posixpath
 import warnings
 
 import docutils
-from docutils import nodes
 import packaging.version
 import sphinx.builders
+from docutils import nodes
 from sphinx.util import rst
 from sphinx.util.docutils import sphinx_domains
 from sphinx.util.fileutil import copy_asset
@@ -22,10 +22,13 @@ TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "templates")
 # docutils has since deprecated traverse so for packages that don't
 # use sphinx-rtd-theme (and will fetch 0.19.0) using findall will
 # avoid the deprecation warnings
-if packaging.version.parse(docutils.__version__) >= packaging.version.parse('0.19.0'):
+if packaging.version.parse(docutils.__version__) >= packaging.version.parse("0.19.0"):
+
     def traverse(doctree, *args, **kwargs):
         return doctree.findall(*args, **kwargs)
+
 else:
+
     def traverse(doctree, *args, **kwargs):
         return doctree.traverse(*args, **kwargs)
 


### PR DESCRIPTION
see the code comment for some details but somehow
the docs build without errors or warnings but the side menu for sphinx-rtd-theme fails to scroll

I think this is a combination of sphinx-asdf, docutils and sphinx-rtd-theme.

Testing locally the changes in this PR appears to fix it for jwst (for the current sphinx-rtd-theme)


Part of the issue here appears to be that sphinx-rtd-theme sets an upper pin on docutils limiting it to <0.19. 0.18.1 was released in December 2021 and contains a bug in findall (which is the recommended replacement for traverse that is deprecated in newer docutils).

Docutils 18.1 has broken findall due to this issue:https://sourceforge.net/p/docutils/bugs/448/ fixed in docutils 19https://sourceforge.net/p/docutils/code/9067/ which incorrectly assigns the first node, which results in adding the bootstrap template from sphinx-asdf to the page. This conflicts with the css from sphinx-rtd-template and results in the broken menu.

I opened a test PR on JWST to see the docs built with the source branch for this PR here:
https://github.com/spacetelescope/jwst/pull/7776
with built docs:
https://jwst-pipeline--7776.org.readthedocs.build/en/7776/

Note that this is impacting jwst, roman and asdf docs which all use sphinx-rtd-theme.