### PR TITLE
remove use of deprecated sphinx.testing.path

### DIFF
--- a/tests/test_sphinx_asdf.py
+++ b/tests/test_sphinx_asdf.py
@@ -1,17 +1,17 @@
 import os
 import pickle
+from pathlib import Path
 from tempfile import gettempdir
 
 import pytest
 from docutils import nodes
-from sphinx.testing.path import path
 
 from sphinx_asdf import nodes as sa_nodes
 
 
 @pytest.fixture(scope="session")
 def rootdir():
-    return path(__file__).parent.abspath() / "roots"
+    return Path(__file__).parent.absolute() / "roots"
 
 
 @pytest.fixture(scope="session")
@@ -23,7 +23,7 @@ def sphinx_test_tempdir():
     def make_tmpdir():
         return os.path.join(gettempdir(), str(os.getpid()))
 
-    return path(os.environ.get("SPHINX_TEST_TEMPDIR", make_tmpdir())).abspath()
+    return Path(os.environ.get("SPHINX_TEST_TEMPDIR", make_tmpdir())).absolute()
 
 
 @pytest.mark.sphinx("dummy", testroot="basic-generation")


### PR DESCRIPTION
sphinx.testing.path is deprecated as of sphinx 7.2. There appears to be uses of `path` which expect that `path` is a `pathlib.Path` that provides `mkdir` (the deprecated sphinx.testing.path does not). This is leading to CI failures on the main branch: https://github.com/asdf-format/sphinx-asdf/actions/runs/6085352414/job/16509216973#step:5:260

This PR removes use of sphinx.testing.path and replaces it with the suggested pathlib.