### PR TITLE
Update ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for pip
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/sphinx_asdf_ci.yml
+++ b/.github/workflows/sphinx_asdf_ci.yml
@@ -116,11 +116,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
@@ -130,6 +130,6 @@ jobs:
         run: tox -e ${{ matrix.toxenv }}
       - name: Upload Code Coverage
         if: ${{ contains(matrix.toxenv,'coverage') }}
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml

--- a/.github/workflows/sphinx_asdf_ci.yml
+++ b/.github/workflows/sphinx_asdf_ci.yml
@@ -109,20 +109,10 @@ jobs:
             os: ubuntu-latest
             toxenv: roman_datamodels
 
-          - name: romancal Document Build
-            python-version: "3.11"
-            os: ubuntu-latest
-            toxenv: romancal
-
           - name: stdatamodels Document Build
             python-version: "3.10"
             os: ubuntu-latest
             toxenv: stdatamodels
-
-          - name: jwst Document Build
-            python-version: "3.11"
-            os: ubuntu-latest
-            toxenv: jwst
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-write_to = "sphinx_asdf/_version.py"
+version_file = "sphinx_asdf/_version.py"
 
 [tool.black]
 line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -93,17 +93,6 @@ commands=
     pip install ./roman_datamodels[docs]
     sphinx-build roman_datamodels/docs roman_datamodels/docs/build
 
-[testenv:romancal]
-changedir={envtmpdir}
-deps=
-    sphinx
-allowlist_externals=
-    git
-commands=
-    git clone https://github.com/spacetelescope/romancal
-    pip install ./romancal[docs]
-    sphinx-build romancal/docs romancal/docs/build
-
 [testenv:stdatamodels]
 changedir={envtmpdir}
 deps=
@@ -114,17 +103,6 @@ commands=
     git clone https://github.com/spacetelescope/stdatamodels
     pip install ./stdatamodels[docs]
     sphinx-build stdatamodels/docs/source stdatamodels/docs/build
-
-[testenv:jwst]
-changedir={envtmpdir}
-deps=
-    sphinx
-allowlist_externals=
-    git
-commands=
-    git clone https://github.com/spacetelescope/jwst
-    pip install ./jwst[docs]
-    sphinx-build jwst/docs jwst/docs/build
 
 [testenv:twine]
 deps=


### PR DESCRIPTION
"Spring" cleaning:

- remove jwst and romancal docs build CI jobs as these no longer use sphinx-asdf
- update setuptools scm `write_to` entry in `pyproject.toml` to the non-deprecated `version_file`
- update github actions to newest versions (to avoid deprecation warnings)
- add dependabot to check python and github actions versions