### PR TITLE
fix example rendering when example contains an asdf_standard requirement

### DIFF
--- a/sphinx_asdf/directives.py
+++ b/sphinx_asdf/directives.py
@@ -413,6 +413,6 @@ class AsdfSchema(SphinxDirective):
             desc_text = self._markdown_to_nodes(example[0] + ":", filename)
             description = example_description(None, *desc_text)
             node.append(description)
-            node.append(nodes.literal_block(text=example[1], language="yaml"))
+            node.append(nodes.literal_block(text=example[-1], language="yaml"))
             examples.append(node)
         return examples


### PR DESCRIPTION
Schema examples can contain >2 items when they contain an asdf_standard requirement (as seen in the current `time-1.2.0` schema:
https://github.com/asdf-format/asdf-standard/blob/6aa1f965607dc2e6bc1e69da8479a335026e3c49/resources/schemas/stsci.edu/asdf/time/time-1.2.0.yaml#L36-L40
```yaml
  -
    - Example ISO time
    - asdf-standard-1.6.0
    - |
        !time/time-1.2.0 "2000-12-31T13:05:27.737"
```
These examples currently do not render properly with sphinx-asdf where the entire example becomes `asdf-standard-1.6.0`. See https://asdf-standard.readthedocs.io/en/1.0.3/generated/stsci.edu/asdf/time/time-1.2.0.html#Examples

This PR fixes the above issue.