### PR TITLE
switch to open astronomy release workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,14 +3,12 @@ name: Publish to PyPI
 on:
   release:
     types: [released]
+  workflow_dispatch:
 
 jobs:
   publish:
-    uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
-      test: false
-      build_platform_wheels: false # Set to true if your package contains a C extension
+      upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
     secrets:
-      user: ${{ secrets.PYPI_USERNAME_ASDF_MAINTAINER }}
-      password: ${{ secrets.PYPI_PASSWORD_ASDF_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
-      test_password: ${{ secrets.PYPI_PASSWORD_ASDF_MAINTAINER_TEST }}
+      pypi_token: ${{ secrets.PYPI_PASSWORD_ASDF_MAINTAINER }}


### PR DESCRIPTION
~I don't know if this is related but I just attempted to make a 0.2.4 release:
https://github.com/asdf-format/sphinx-asdf/releases/tag/0.2.4
which never triggered the release workflow:
https://github.com/asdf-format/sphinx-asdf/actions/workflows/publish-to-pypi.yml~

EDIT: ~actions are "degraded" https://www.githubstatus.com/ the CI for this PR is also not triggering.~
EDIT: actions seem to be coming back

This PR updates the `publish-to-pypi` (release) workflow to use the `OpenAstronomy` `publish_pure_python.yml@v1` workflow.