### PR TITLE
remove roman_datamodels from ci

### DIFF
--- a/.github/workflows/sphinx_asdf_ci.yml
+++ b/.github/workflows/sphinx_asdf_ci.yml
@@ -104,11 +104,6 @@ jobs:
             os: ubuntu-latest
             toxenv: rad
 
-          - name: roman_datamodels Document Build
-            python-version: "3.11"
-            os: ubuntu-latest
-            toxenv: roman_datamodels
-
           - name: stdatamodels Document Build
             python-version: "3.10"
             os: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -82,17 +82,6 @@ commands=
     pip install ./rad[docs]
     sphinx-build rad/docs rad/docs/build
 
-[testenv:roman_datamodels]
-changedir={envtmpdir}
-deps=
-    sphinx
-allowlist_externals=
-    git
-commands=
-    git clone https://github.com/spacetelescope/roman_datamodels
-    pip install ./roman_datamodels[docs]
-    sphinx-build roman_datamodels/docs roman_datamodels/docs/build
-
 [testenv:stdatamodels]
 changedir={envtmpdir}
 deps=


### PR DESCRIPTION
https://github.com/spacetelescope/roman_datamodels/pull/326 removed sphinx-asdf as a dependency for roman_datamodels (which was unused in roman_datamodels).

This PR removes roman_datamodels from the CI for sphinx-asdf.