### PR TITLE
display titles for properties

### DIFF
--- a/sphinx_asdf/directives.py
+++ b/sphinx_asdf/directives.py
@@ -381,6 +381,7 @@ class AsdfSchema(SphinxDirective):
         return schema_properties(None, *[container_node], id=path)
 
     def _create_property_node(self, name, tree, required, path=""):
+        title = tree.get("title", "")
         description = tree.get("description", "")
 
         if "$ref" in tree:
@@ -397,6 +398,7 @@ class AsdfSchema(SphinxDirective):
         prop = schema_property(id=path)
         prop.append(schema_property_name(text=name))
         prop.append(schema_property_details(typ=typ, required=required, ref=ref))
+        prop.append(self._parse_title(title, ""))
         prop.append(self._parse_description(description, ""))
         if typ != "object":
             prop.extend(self._process_validation_keywords(tree, typename=typ, path=path))


### PR DESCRIPTION
Some RAD schemas contain "title" keywords nested in "properties":
https://github.com/spacetelescope/rad/blob/5822f5eed455f4580bf5d04b9d6babf95f71de22/src/rad/resources/schemas/mosaic_basic-1.0.0.yaml#L11
However these are not rendered by sphinx-asdf
https://rad.readthedocs.io/en/latest/generated/schemas/mosaic_basic-1.0.0.html

This PR updates the schema rendering to display titles for properties.

The modified code is uncovered so there are no unit tests to update.

https://github.com/spacetelescope/rad/pull/551 is a test RAD PR using the changes in this PR and show the rendered titles:
https://rad--551.org.readthedocs.build/en/551/generated/schemas/mosaic_basic-1.0.0.html