### PR TITLE
fix warning about sphinx9 removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 version_file = "sphinx_asdf/_version.py"
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    'error',
+]
+
 [tool.black]
 line-length = 120
 force-exclude = '''

--- a/sphinx_asdf/connections.py
+++ b/sphinx_asdf/connections.py
@@ -109,10 +109,9 @@ def autogenerate_schema_docs(app):
 
 
 def update_app_config(app, config):
-    from pkg_resources import get_distribution
+    from importlib.metadata import version
 
-    dist = get_distribution("sphinx_asdf")
-    config.html_context["sphinx_asdf_version"] = dist.version
+    config.html_context["sphinx_asdf_version"] = version("sphinx_asdf")
 
 
 def normalize_name(name):

--- a/sphinx_asdf/connections.py
+++ b/sphinx_asdf/connections.py
@@ -94,7 +94,7 @@ def create_schema_docs(app, schemas):
 def autogenerate_schema_docs(app):
     env = app.env
 
-    genfiles = [env.doc2path(x, base=None) for x in env.found_docs if posixpath.isfile(env.doc2path(x))]
+    genfiles = [str(env.doc2path(x, base=None)) for x in env.found_docs if posixpath.isfile(env.doc2path(x))]
 
     if not genfiles:
         return


### PR DESCRIPTION
Fixes: https://github.com/asdf-format/sphinx-asdf/issues/100
Sphinx9 will drop supporting paths as strings.

I also turned CI warnings into errors which revealed a `pkg_resources` usage that this PR switches for the now standard `importlib`.

RAD docs built with this PR: https://rad--563.org.readthedocs.build/en/563/
show no warnings.