### PR TITLE
update pyproject.toml to fix warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
   - id: check-added-large-files
   - id: check-ast
@@ -26,7 +26,7 @@ repos:
     - id: text-unicode-replacement-char
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.6
+  rev: v2.4.1
   hooks:
     - id: codespell
       args: ["--write-changes"]
@@ -40,22 +40,22 @@ repos:
       exclude: "asdf/(extern||_jsonschema)/.*"
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.1.1'
+  rev: 'v0.11.10'
   hooks:
     - id: ruff
       args: ["--fix"]
 
 - repo: https://github.com/psf/black
-  rev: 23.10.1
+  rev: 25.1.0
   hooks:
     - id: black
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: '1.16.0'
+  rev: '1.19.1'
   hooks:
     - id: blacken-docs
 
 - repo: https://github.com/abravalheri/validate-pyproject
-  rev: "v0.15"
+  rev: "v0.24.1"
   hooks:
     - id: validate-pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,18 +2,13 @@
 name = "sphinx-asdf"
 description = "Sphinx plugin for generating documentation from ASDF schemas"
 readme = 'README.rst'
-license = { file = 'LICENSE' }
+license-files = ['LICENSE']
 authors = [{ name = 'The ASDF Developers', email = 'help@stsci.edu' }]
 requires-python = '>=3.9'
 classifiers = [
   'Development Status :: 5 - Production/Stable',
-  "License :: OSI Approved :: BSD License",
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
-  'Programming Language :: Python :: 3.9',
-  'Programming Language :: Python :: 3.10',
-  'Programming Language :: Python :: 3.11',
-  'Programming Language :: Python :: 3.12',
 ]
 dynamic = [
   'version',
@@ -76,6 +71,8 @@ line-length = 120
 [tool.ruff]
 target-version = "py38"
 line-length = 120
+
+[tool.ruff.lint]
 select = [
     # minimal set to match pre-ruff behavior
     "E", # pycodestyle

--- a/sphinx_asdf/connections.py
+++ b/sphinx_asdf/connections.py
@@ -100,7 +100,7 @@ def autogenerate_schema_docs(app):
         return
 
     ext = list(app.config.source_suffix)
-    genfiles = [genfile + (not genfile.endswith(tuple(ext)) and ext[0] or "") for genfile in genfiles]
+    genfiles = [genfile + ((not genfile.endswith(tuple(ext)) and ext[0]) or "") for genfile in genfiles]
 
     # Read all source documentation files and parse all asdf-schema directives
     schemas = find_autoschema_references(app, genfiles)


### PR DESCRIPTION
Update pyproject.toml to avoid warnings about license files from setuptools.

Required updating pre-commit hooks.