### PR TITLE
enable ref definitions

### DIFF
--- a/sphinx_asdf/directives.py
+++ b/sphinx_asdf/directives.py
@@ -135,10 +135,16 @@ class AsdfSchema(SphinxDirective):
         if "definitions" in schema:
             docnodes.append(section_header(text=INTERNAL_DEFINITIONS_SECTION_TITLE))
             for name in schema["definitions"]:
+                if name == "$ref":
+                    ref = self._create_ref_node(schema["definitions"]["$ref"])
                 path = f"definitions-{name}"
                 tree = schema["definitions"][name]
-                required = schema.get("required", [])
-                docnodes.append(self._create_property_node(name, tree, name in required, path=path))
+                if name == "$ref" and isinstance(tree, str):
+                    ref = self._create_ref_node(tree)
+                    docnodes.append(schema_properties(None, *[ref], id=path))
+                else:
+                    required = schema.get("required", [])
+                    docnodes.append(self._create_property_node(name, tree, name in required, path=path))
 
         docnodes.append(section_header(text=ORIGINAL_SCHEMA_SECTION_TITLE))
         docnodes.append(nodes.literal_block(text=raw_content, language="yaml"))


### PR DESCRIPTION
This fixes an issue preventing adding the new catalog table schemas to the rad documentation because they contain:
```
definitions:
  $ref: ...
```
which causes sphinx asdf to crash.

This fixes the issue but also revels that sphinx asdf doesn't render "unrestricted" objects which is pretty unhelpful. Since every column just shows `This node has no type definition (unrestricted)`. It looks like there are several issues here including:
- `not` being unsupported
- the doc rendering considering only a narrow selection of schemas as "restricted"

I will open this for review so we can at least get the table schemas added to rad and then follow up work (which might be a rather major rehaul of this package) can:
- add `not` support
- render more schemas (and not just describe then as "unrestricted")